### PR TITLE
Add synonym endpoint. Closes #2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:14.04
+
+MAINTAINER Andy Halterman <ahalterman0@gmail.com>
+
+RUN echo "deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -sc) main universe" >> /etc/apt/sources.list
+
+RUN apt-get update && apt-get install -y git wget tar \
+ build-essential python-dev libopenblas-dev python-numpy python-scipy
+RUN apt-get install -y python-pip
+COPY . /app/
+RUN pip install -r /app/requirements.txt
+RUN pip install git+https://github.com/openeventdata/petrarch2/
+
+WORKDIR /app
+RUN wget https://s3.amazonaws.com/mordecai-geo/GoogleNews-vectors-negative300.bin.gz
+
+#RUN mkdir /home/ubuntu
+#WORKDIR /home/ubuntu
+
+#RUN git clone https://github.com/mit-nlp/MITIE.git
+#WORKDIR /home/ubuntu/MITIE
+#
+#RUN wget http://sourceforge.net/projects/mitie/files/binaries/MITIE-models-v0.2.tar.bz2
+#RUN tar --no-same-owner -xjf MITIE-models-v0.2.tar.bz2
+#RUN mkdir /home/ubuntu/MITIE/mitielib/build
+#RUN cd mitielib/build; cmake ..
+#RUN cd mitielib/build; cmake --build . --config Release --target install
+#RUN pip install git+https://github.com/caerusassociates/mitie-py.git
+
+EXPOSE 5000
+CMD ["python", "/app/app.py"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # night_ridir
-Containerized tools for event data dictionary development
+Containerized tools for event data dictionary development, including:
 
-Docker
+- noun and verb extraction, using the `/get_phrases` endpoint
+- automated word2vec "synonym" discovery with the `/get_synonyms` endpoint
+
+Docker Setup
 -------
 
 From inside this directory, you can build the image by running
@@ -19,6 +22,8 @@ docker run -d -p 5000:5000 nr_tools
 Example
 -------
 
+Pass a sentence and its CoreNLP parse to get back phrases and codings (if applicable):
+
 ```
 curl -XPOST -H "Content-Type: application/json" --data '{"text" : "Hundreds of Egyptian journalists rallied in Cairo on Wednesday in an escalating standoff with police, threatening a possible strike by media workers if demands including the dismissal of the interior minister are not met.", "parse" : "(ROOT (S (NP (NP (NNS Hundreds)) (PP (IN of) (NP (JJ Egyptian) (NNS journalists)))) (VP (VBD rallied) (PP (IN in) (NP (NNP Cairo))) (PP (IN on) (NP (NNP Wednesday))) (PP (IN in) (NP (NP (DT an) (VBG escalating) (NN standoff)) (PP (IN with) (NP (NN police))))) (, ,) (S (VP (VBG threatening) (NP (DT a) (JJ possible) (NN strike)) (PP (IN by) (NP (NNS media) (NNS workers))) (SBAR (IN if) (S (NP (NP (NNS demands)) (PP (VBG including) (NP (NP (DT the) (NN dismissal)) (PP (IN of) (NP (DT the) (JJ interior) (NN minister)))))) (VP (VBP are) (RB not) (VP (VBN met)))))))) (. .)))"}' 'http://localhost:5000/get_phrases'
 ```
@@ -30,4 +35,28 @@ should return
 "noun_coding": [["EGYMED"], ["EGY"], ["~COP"], ["~COP"], ["~MEDLAB"], ["~GOV"], ["~GOV"], ["~GOV"]], 
 "nouns": [[" EGYPTIAN", " JOURNALISTS"], [" CAIRO"], [" POLICE"], [" POLICE"], [" MEDIA", " WORKERS"], [" INTERIOR MINISTER"], [" INTERIOR MINISTER"], [" INTERIOR MINISTER"]], 
 "verb_coding": "150"}
+```
+
+Pass a list of word(s) to get their word2vec synonyms:
+
+```
+curl -XPOST -H "Content-Type: application/json" --data '{"text" : ["artillery"]}' 'http://localhost:5000/get_synonyms'
+```
+
+Expect a list of "synonyms" back:
+
+``` 
+["BRITISH_TROOPS", "FORCES_IN", "WAR_WITH", "ANTIAIRCRAFT",
+"ARTILLERY_BOMBARDMENT", "MACHINEGUN_FIRE", "MORTAR_PLATOON",
+"CARPATHIAN_FOREST", "TARGETED_BY", "AIR_STRIKES", "WARPLANES", "ANTITANK",
+"DRAGOON_GUARDS", "ARTILLERY_BARRAGES", "LEGION_OF", "ORDNANCE", "IN_KASHMIR",
+"SPECIAL_OPERATIONS", "MM_HOWITZER", "SHELLFIRE", "ARTILLERY",
+"ARTILLERY_SHELLS", "CANNONEERS", "BLAST_KILLS", "ARMY_AND", "HOWITZERS",
+"##MM_CANNON", "ARTILLERY_REGIMENT", "FIELD_ARTILLERY", "CAVALRY",
+"SWEDISH_METALLERS", "INFANTRY", "ARTILLERY_MORTARS", "ARTILLERIES",
+"FRONTMAN", "REGIMENT", "ARTILLERY_BARRAGE", "PARACHUTE_REGIMENT",
+"ARMOURED_REGIMENT", "RIFLES", "MORTARS", "ARMY_ORDNANCE",
+"ARTILLERY_SHELLING", "ARTILLERY_BRIGADE", "MISSILES", "###MM_HOWITZERS",
+"BC_AS_GEN", "MORTAR", "TANKS_ARTILLERY", "ARTILLERY_BATTALION", "KHYBER",
+"CAR_BOMB", "DRONE", "BOMBARDMENT"]
 ```

--- a/app.py
+++ b/app.py
@@ -4,11 +4,13 @@ from tornado.ioloop import IOLoop
 from tornado.wsgi import WSGIContainer
 from tornado.httpserver import HTTPServer
 from resources.extract_phrases import PhraseExtractAPI
+from resources.synonymizer import SynonymizeAPI
 
 app = Flask(__name__)
 api = Api(app)
 
 api.add_resource(PhraseExtractAPI, '/get_phrases')
+api.add_resource(SynonymizeAPI, '/get_synonyms')
 
 if __name__ == '__main__':
     http_server = HTTPServer(WSGIContainer(app))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Flask==0.10.1
 Flask-HTTPAuth==2.5.0
 Flask-RESTful==0.3.3
 tornado==4.2
+gensim==0.12.4
+smart_open==1.3.2

--- a/resources/synonymizer.py
+++ b/resources/synonymizer.py
@@ -1,0 +1,38 @@
+from gensim.models import Word2Vec
+import re
+
+word2vec_model = "/media/data/GoogleNews-vectors-negative300.bin.gz"
+
+prebuilt = Word2Vec.load_word2vec_format(word2vec_model, binary=True)
+vocab_set = set(prebuilt.vocab.keys())
+
+def get_synonyms(word)
+    word_upper = word.upper()
+    word_title = word[0].capitalize() + word[1:].lower()
+    word_lower = word.lower()
+
+    word_combo = [word_upper, word_title, word_lower]
+    print word_combo
+
+    results_list = []
+    for w in word_combo:
+        try:
+            results = prebuilt.most_similar(positive=[w], topn=20)
+            results_list.extend([i[0].upper() for i in results])
+            #print [i[1] for i in results]
+        except KeyError:
+            pass
+
+    return set(results_list)
+
+def synonymize(word):
+    print type(word)
+    if len(word) == 1:
+        word = word[0]
+        word = re.sub(" ", "_", word)
+        syns = get_synonyms(word)
+    if len(word) > 1:
+        word_list = re.sub(" ", "_", word)
+        syns = get_synonyms(word)
+    # finish here. Handle lists of multiple words by looking up each seperately
+    

--- a/resources/synonymizer.py
+++ b/resources/synonymizer.py
@@ -1,38 +1,76 @@
 from gensim.models import Word2Vec
 import re
+from flask import jsonify, make_response
+from flask.ext.httpauth import HTTPBasicAuth
+from flask.ext.restful import Resource, reqparse
+from flask.ext.restful.representations.json import output_json
+import json
+import ast # de-string incoming list
+import itertools
 
-word2vec_model = "/media/data/GoogleNews-vectors-negative300.bin.gz"
+print "Loading word2vec model"
+#word2vec_model = "/media/data/GoogleNews-vectors-negative300.bin"
+word2vec_model = "/app/GoogleNews-vectors-negative300.bin.gz"
 
 prebuilt = Word2Vec.load_word2vec_format(word2vec_model, binary=True)
 vocab_set = set(prebuilt.vocab.keys())
+print "Done loading"
 
-def get_synonyms(word)
-    word_upper = word.upper()
-    word_title = word[0].capitalize() + word[1:].lower()
-    word_lower = word.lower()
+class SynonymizeAPI(Resource):
+    def __init__(self):
+        self.reqparse = reqparse.RequestParser()
+        self.reqparse.add_argument('text', type=unicode, location='json')
+        super(SynonymizeAPI, self).__init__()
 
-    word_combo = [word_upper, word_title, word_lower]
-    print word_combo
+    def get(self):
+        return """ This service expects a POST in the form '{"text":["journalists"]}'.
+                It returns word2vec 'synonyms' of the term in the form '["REPORTER","INTERVIEWER"]'
+                """
 
-    results_list = []
-    for w in word_combo:
-        try:
-            results = prebuilt.most_similar(positive=[w], topn=20)
-            results_list.extend([i[0].upper() for i in results])
-            #print [i[1] for i in results]
-        except KeyError:
-            pass
-
-    return set(results_list)
-
-def synonymize(word):
-    print type(word)
-    if len(word) == 1:
-        word = word[0]
-        word = re.sub(" ", "_", word)
-        syns = get_synonyms(word)
-    if len(word) > 1:
-        word_list = re.sub(" ", "_", word)
-        syns = get_synonyms(word)
-    # finish here. Handle lists of multiple words by looking up each seperately
+    def get_synonyms(self, word, match_n = 20):
+        word_upper = word.upper()
+        word_title = word[0].capitalize() + word[1:].lower()
+        word_lower = word.lower()
     
+        word_combo = [word_upper, word_title, word_lower]
+    
+        results_list = []
+        for w in word_combo:
+            try:
+                results = prebuilt.most_similar(positive=[w], topn = match_n)
+                results_list.extend([i[0].upper() for i in results])
+                #print [i[1] for i in results]
+            except KeyError:
+                pass
+        return list(set(results_list))
+    
+    def post(self):
+        args = self.reqparse.parse_args()
+        x = args['text']
+        words = ast.literal_eval(x)
+        print words
+        print type(words)
+        print len(words)
+        if len(words) == 1:
+            word = words[0]
+            word = re.sub(" ", "_", word)
+            syns = self.get_synonyms(word)
+        #if len(word) > 1:
+        #    word_list = re.sub(" ", "_", word)
+        #    syns = self.get_synonyms(word)
+        if len(words) == 2:
+            word_list = [re.sub(" ", "_", w) for w in words]
+            syns = []
+            for n, w in enumerate(word_list):
+                syns.append(self.get_synonyms(w, match_n = 4))
+            t = [zip(x, syns[1]) for x in itertools.permutations(syns[0], len(syns[1]))]
+            x = []
+            for i in t:
+                for j in i:
+                    p = j[0] + "_" + j[1]
+                    x.append(p)
+            syns = list(set(x)) # get uniques
+        if len(words) == 0 or len(words) > 2:
+            print "Word length is 0 or greater than 2"
+            syns = []
+        return syns


### PR DESCRIPTION
Add an endpoint, `/get_synonyms`, that takes a list of word(s) and returns word2vec "synonyms".
It runs in Flask and is Dockerized.

Note that building the image now takes much longer as it has to install numpy and gensim and has to download the ~3 GB pretrained word2vec model.
